### PR TITLE
#10: Adding initial code/configurations to showcase a simple Java + Maven project

### DIFF
--- a/ci/java-mvn/.gitignore
+++ b/ci/java-mvn/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/ci/java-mvn/pom.xml
+++ b/ci/java-mvn/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.ryandeford.samples</groupId>
+    <artifactId>java-mvn</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/ci/java-mvn/src/main/java/io/ryandeford/samples/data/SampleResultData.java
+++ b/ci/java-mvn/src/main/java/io/ryandeford/samples/data/SampleResultData.java
@@ -1,0 +1,15 @@
+package io.ryandeford.samples.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SampleResultData {
+    @Builder.Default
+    private String message = "Default Sample Message";
+}

--- a/ci/java-mvn/src/main/java/io/ryandeford/samples/implementations/SampleServiceDefaultImpl.java
+++ b/ci/java-mvn/src/main/java/io/ryandeford/samples/implementations/SampleServiceDefaultImpl.java
@@ -1,0 +1,16 @@
+package io.ryandeford.samples.implementations;
+
+import io.ryandeford.samples.data.SampleResultData;
+import io.ryandeford.samples.interfaces.SampleService;
+
+public class SampleServiceDefaultImpl implements SampleService {
+    @Override
+    public SampleResultData executeSampleAction() {
+        return SampleResultData.builder().build();
+    }
+
+    @Override
+    public SampleResultData executeSampleActionWithMessage(String message) {
+        return SampleResultData.builder().message(message).build();
+    }
+}

--- a/ci/java-mvn/src/main/java/io/ryandeford/samples/interfaces/SampleService.java
+++ b/ci/java-mvn/src/main/java/io/ryandeford/samples/interfaces/SampleService.java
@@ -1,0 +1,9 @@
+package io.ryandeford.samples.interfaces;
+
+import io.ryandeford.samples.data.SampleResultData;
+
+public interface SampleService {
+    public SampleResultData executeSampleAction();
+
+    public SampleResultData executeSampleActionWithMessage(String message);
+}

--- a/ci/java-mvn/src/main/java/io/ryandeford/samples/utils/SampleConstants.java
+++ b/ci/java-mvn/src/main/java/io/ryandeford/samples/utils/SampleConstants.java
@@ -1,0 +1,5 @@
+package io.ryandeford.samples.utils;
+
+public class SampleConstants {
+    public static final String DEFAULT_SAMPLE_RESULT_MESSAGE = "Default Sample Message";
+}

--- a/ci/java-mvn/src/test/java/io/ryandeford/samples/data/SampleResultDataTest.java
+++ b/ci/java-mvn/src/test/java/io/ryandeford/samples/data/SampleResultDataTest.java
@@ -1,0 +1,39 @@
+package io.ryandeford.samples.data;
+
+import io.ryandeford.samples.test.SampleTestConstants;
+import io.ryandeford.samples.utils.SampleConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SampleResultDataTest {
+
+    @Test
+    void createSampleResultDataDefaultConstructor() {
+        SampleResultData data = new SampleResultData();
+        assertEquals(SampleConstants.DEFAULT_SAMPLE_RESULT_MESSAGE, data.getMessage());
+    }
+
+    @Test
+    void createSampleResultDataMessageConstructor() {
+        String message = "Custom Sample Message";
+        SampleResultData data = new SampleResultData(message);
+        assertEquals(message, data.getMessage());
+    }
+
+    @Test
+    void createSampleResultDataBuilderDefault() {
+        SampleResultData data = SampleResultData.builder().build();
+        assertEquals(SampleConstants.DEFAULT_SAMPLE_RESULT_MESSAGE, data.getMessage());
+    }
+
+    @Test
+    void createSampleResultDataBuilderCustomMessage() {
+        SampleResultData data = SampleResultData.builder()
+                .message(SampleTestConstants.CUSTOM_SAMPLE_RESULT_MESSAGE)
+                .build();
+        assertEquals(SampleTestConstants.CUSTOM_SAMPLE_RESULT_MESSAGE, data.getMessage());
+    }
+
+    // Note: There are all kinds of tests we could create here, but this is just a sample project
+}

--- a/ci/java-mvn/src/test/java/io/ryandeford/samples/implementations/SampleServiceDefaultImplTest.java
+++ b/ci/java-mvn/src/test/java/io/ryandeford/samples/implementations/SampleServiceDefaultImplTest.java
@@ -1,0 +1,29 @@
+package io.ryandeford.samples.implementations;
+
+import io.ryandeford.samples.data.SampleResultData;
+import io.ryandeford.samples.interfaces.SampleService;
+import io.ryandeford.samples.utils.SampleConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SampleServiceDefaultImplTest {
+
+    @Test
+    void executeSample() {
+        SampleService service = new SampleServiceDefaultImpl();
+        SampleResultData result = service.executeSampleAction();
+        assertInstanceOf(SampleResultData.class, result);
+        assertEquals(SampleConstants.DEFAULT_SAMPLE_RESULT_MESSAGE, result.getMessage());
+    }
+
+    @Test
+    void executeSampleMessage() {
+        String message = "Custom Sample Message";
+
+        SampleService service = new SampleServiceDefaultImpl();
+        SampleResultData result = service.executeSampleActionWithMessage(message);
+        assertInstanceOf(SampleResultData.class, result);
+        assertEquals(message, result.getMessage());
+    }
+}

--- a/ci/java-mvn/src/test/java/io/ryandeford/samples/test/SampleTestConstants.java
+++ b/ci/java-mvn/src/test/java/io/ryandeford/samples/test/SampleTestConstants.java
@@ -1,0 +1,5 @@
+package io.ryandeford.samples.test;
+
+public class SampleTestConstants {
+    public static final String CUSTOM_SAMPLE_RESULT_MESSAGE = "Test Custom Sample Message";
+}

--- a/ci/java-mvn/src/test/java/io/ryandeford/samples/utils/SampleConstantsTest.java
+++ b/ci/java-mvn/src/test/java/io/ryandeford/samples/utils/SampleConstantsTest.java
@@ -1,0 +1,13 @@
+package io.ryandeford.samples.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SampleConstantsTest {
+
+    @Test
+    void verifyDefaultSampleResultMessage() {
+        assertEquals("Default Sample Message", SampleConstants.DEFAULT_SAMPLE_RESULT_MESSAGE);
+    }
+}


### PR DESCRIPTION
Adding a super simple Java w/ Maven project to showcase how to do things like:

- Manage Dependencies
- Build Source Code
- Execute Tests
- Package Final Artifact

Here's a simple way to perform core actions via the command line: `mvn clean package`

I also added a handful of `Lombok` usages to demonstrate cool annotation-driven code generation features.